### PR TITLE
Added option to append modification date as a query string

### DIFF
--- a/lib/css.php
+++ b/lib/css.php
@@ -32,7 +32,12 @@ class CSS extends \Kirby\Component\CSS {
 
     if(file_exists($file)) {
       $mod = f::modified($file);
-      $url = dirname($url) . '/' . f::name($url) . '.' . $mod . '.css';
+      if(\c::get('cachebuster.querystring.enable')) {
+        $url .= '?v=' . $mod;
+      }
+      else {
+        $url = dirname($url) . '/' . f::name($url) . '.' . $mod . '.css';
+      }
     }
 
     return parent::tag($url, $media);

--- a/lib/js.php
+++ b/lib/js.php
@@ -32,7 +32,12 @@ class JS extends \Kirby\Component\JS {
 
     if(file_exists($file)) {
       $mod = f::modified($file);
-      $src = dirname($src) . '/' . f::name($src) . '.' . $mod . '.js';
+      if(\c::get('cachebuster.querystring.enable')) {
+        $src .= '?v=' . $mod;
+      }
+      else {
+        $src = dirname($src) . '/' . f::name($src) . '.' . $mod . '.js';
+      }
     }
 
     return parent::tag($src, $async);


### PR DESCRIPTION
I intend to run Kirby on Google App Engine, which doesn't have Apache or Nginx rewrite capabilities. Using the modification date as a query string, instead of part the filename greatly simplifies configuration in this scenario.

I haven't updated the `readme.md`, but here's some usage information:

```
c::set('cachebuster', true);
c::set('cachebuster.querystring.enable', true);
```

Will output css tags like:
```
<link rel="stylesheet" href="http://localhost:8080/assets/css/site.css?v=1505768483">
```

I also welcome any feedback. If these changes look good, I'm more than happy to update the `readme.md` to reflect changes.